### PR TITLE
Infura-related fixes

### DIFF
--- a/raiden_installer/ethereum_rpc.py
+++ b/raiden_installer/ethereum_rpc.py
@@ -1,3 +1,4 @@
+from re import search
 from urllib.parse import urlparse
 
 from web3 import HTTPProvider, Web3
@@ -31,6 +32,7 @@ class EthereumRPCProvider:
 
 class Infura(EthereumRPCProvider):
     URL_PATTERN = "https://{network_name}.infura.io:443/v3/{project_id}"
+    ID_REGEX = "(^|(?<=(infura\.io\/v[\d]\/)))[\da-fA-F]{32}$"
 
     def __init__(self, url):
         super().__init__(url)
@@ -51,13 +53,13 @@ class Infura(EthereumRPCProvider):
 
     @classmethod
     def make(cls, network: Network, project_id: str):
+        project_id = project_id[-32:]
         return cls(cls.URL_PATTERN.format(network_name=network.name, project_id=project_id))
 
     @staticmethod
+    def is_valid_project_id_or_endpoint(id_string: str) -> bool:
+        return bool(search(Infura.ID_REGEX, id_string))
+
+    @staticmethod
     def is_valid_project_id(id_string: str) -> bool:
-        try:
-            # It should an hex string
-            int(id_string, 16)
-            return len(id_string) == 32
-        except ValueError:
-            return False
+        return len(id_string) == 32 and Infura.is_valid_project_id_or_endpoint(id_string)

--- a/raiden_installer/utils.py
+++ b/raiden_installer/utils.py
@@ -1,3 +1,5 @@
+import requests
+
 from raiden_installer import log
 from raiden_contracts.contract_manager import get_contracts_deployment_info
 
@@ -51,3 +53,16 @@ def send_raw_transaction(w3, account, contract_function, *args, **kw):
     tx_hash = w3.eth.sendRawTransaction(signed.rawTransaction)
 
     return w3.eth.waitForTransactionReceipt(tx_hash)
+
+
+def check_eth_node_responsivity(url):
+    try:
+        body = dict(jsonrpc="2.0", method="web3_clientVersion", params=[], id=1)
+        response = requests.post(url, json=body)
+        if(response.status_code == 401):
+            raise ValueError(
+                "Unauthorized to make requests to ethereum node."
+                "Maybe the Infura project ID is wrong?"
+            )
+    except requests.RequestException as e:
+        raise ValueError(str(e) or "Unspecified Request Exception")

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -35,6 +35,7 @@ from raiden_installer.transactions import (
     get_token_deposit,
     mint_tokens,
 )
+from raiden_installer.utils import check_eth_node_responsivity
 
 
 DEBUG = "RAIDEN_INSTALLER_DEBUG" in os.environ
@@ -168,6 +169,12 @@ class AsyncTaskHandler(WebSocketHandler):
                 ethereum_rpc_provider = EthereumRPCProvider(url_or_infura_id)
 
             account = Account.create()
+
+            try:
+                check_eth_node_responsivity(ethereum_rpc_provider.url)
+            except ValueError as e:
+                self._send_error_message(f"Ethereum node unavailable: {e}.")
+                return
 
             conf_file = RaidenConfigurationFile(
                 account,

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -63,9 +63,8 @@ class QuickSetupForm(Form):
         data = field.data.strip()
         parsed_url = urlparse(data)
         is_valid_url = bool(parsed_url.scheme) and bool(parsed_url.netloc)
-        is_valid_project_id = Infura.is_valid_project_id(data)
 
-        if not (is_valid_project_id or is_valid_url):
+        if not (Infura.is_valid_project_id_or_endpoint(data) or is_valid_url):
             raise wtforms.ValidationError("Not a valid URL nor Infura Project ID")
 
 
@@ -163,7 +162,7 @@ class AsyncTaskHandler(WebSocketHandler):
             network = Network.get_by_name(form.data["network"])
             url_or_infura_id = form.data["endpoint"].strip()
 
-            if Infura.is_valid_project_id(url_or_infura_id):
+            if Infura.is_valid_project_id_or_endpoint(url_or_infura_id):
                 ethereum_rpc_provider = Infura.make(network, url_or_infura_id)
             else:
                 ethereum_rpc_provider = EthereumRPCProvider(url_or_infura_id)

--- a/resources/templates/raiden_setup.html
+++ b/resources/templates/raiden_setup.html
@@ -86,8 +86,7 @@
 
 
    // Attaching event handlers
-   infura_project_input.addEventListener("blur", checkIdNotEmpty);
-   infura_project_input.addEventListener("change", checkIdNotEmpty);
+   infura_project_input.addEventListener("input", checkIdNotEmpty);
    submit_button.addEventListener("click", submitConfiguration);
 
  });

--- a/resources/templates/raiden_setup.html
+++ b/resources/templates/raiden_setup.html
@@ -9,7 +9,7 @@
 
 <div class="info-panel">
   <div>
-    <input type="text" name="endpoint" placeholder="Your Infura ID" />
+    <input type="text" name="endpoint" placeholder="Your Infura ID (or Infura endpoint URL)" />
   </div>
   <span class="error" hidden>You need to provide a valid Infura Project ID</span>
 </div>
@@ -30,16 +30,13 @@
    const error_display = document.querySelector("span.error");
    const submit_button = document.querySelector("button");
 
-   function validateInfuraId(evt) {
-     const infura_id = evt.target.value;
-     const error_message = "Infura IDs must be exactly 32 characters long";
+   function checkIdNotEmpty(evt) {
+     const error_message = "Please enter your Infura ID.";
 
-     if (infura_id && infura_id.length != 32) {
+     if (!evt.target.value) {
        error_display.textContent = error_message;
        error_display.hidden = false;
-       if (!submit_button.disabled) {
-         submit_button.disabled = true;
-       }
+       submit_button.disabled = true;
      }
      else {
        error_display.hidden = true;
@@ -89,8 +86,8 @@
 
 
    // Attaching event handlers
-   infura_project_input.addEventListener("blur", validateInfuraId);
-   infura_project_input.addEventListener("change", validateInfuraId);
+   infura_project_input.addEventListener("blur", checkIdNotEmpty);
+   infura_project_input.addEventListener("change", checkIdNotEmpty);
    submit_button.addEventListener("click", submitConfiguration);
 
  });

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from raiden_installer.account import Account
 from raiden_installer.base import RaidenConfigurationFile, PassphraseFile
-from raiden_installer.ethereum_rpc import make_web3_provider
+from raiden_installer.ethereum_rpc import Infura, make_web3_provider
 from raiden_installer.network import Network
 from raiden_installer.tokens import EthereumAmount, TokenAmount, Erc20Token, Wei
 
@@ -91,6 +91,29 @@ class RaidenConfigurationTestCase(unittest.TestCase):
         for config in RaidenConfigurationFile.get_available_configurations():
             config.passphrase_file_path.unlink()
             config.path.unlink()
+
+
+class EthereumRpcProviderTestCase(unittest.TestCase):
+    def test_infura_is_valid_project_id_or_endpoint(self):
+        valid = [
+            "goerli.infura.io/v3/a7a347de4c103495a4a88dc0658db9b2",
+            "36b457de4c103495ada08dc0658db9c3",
+            "ropsten.infura.io/v3/8dc0658db9c34c103495a4a8b145e83a",
+            "ropsten.infura.io/v4/8dc0658db9c34c103495a4a8b145e83a",
+        ]
+        invalid = [
+            "not-infura.net/a7a347de4c103495a4a88dc0658db9b2",
+            "7a347de4c103495a4a88dc0658db9b2",
+            "a7a347de4c103495a4a88dc0658db9b2444",
+            "a7a347de4c103495a4a88gc044658db9b2",
+            "goerli.infura.io/v3/a7a347de4c103495a4a88dc065gdb9b2",
+            "goerli.infura.io/v3/a7a347de4c103495a4a88dc044658db9b2",
+            "goerli.infura.io/v3/a7a34c103495a4a88dc044658db9b2",
+        ]
+        for project_id in valid:
+            self.assertTrue(Infura.is_valid_project_id_or_endpoint(project_id))
+        for project_id in invalid:
+            self.assertFalse(Infura.is_valid_project_id_or_endpoint(project_id))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Accept the endpoint url from Infura's dashboard in place of the project id. In theory, this should already have worked, but the html template had a validation method that rejected inputs longer than 32 bytes. Also, the urls copied from the Infura dashboard are missing the scheme, so the wizard would not accept them.

- Make sure on each launch with a new configuration that the given Eth RPC provider is responsive. This is done in particular to cope with wrong (valid but inexistant) Infura project ids.

Fixes #83 
Fixes #44