### PR TITLE
Fix issue with latest setuptools version #95

### DIFF
--- a/tools/pyinstaller/raiden_webapp.spec
+++ b/tools/pyinstaller/raiden_webapp.spec
@@ -35,6 +35,7 @@ a = Analysis(
         "packaging.version",
         "packaging.specifiers",
         "packaging.requirements",
+        "pkg_resources.py2_warn",
         "web3",
     ],
     hookspath=[HOOKS_FOLDER],


### PR DESCRIPTION
Temporarily adding 'pkg_resources.py2_warn' to the hidden imports