### PR TITLE
Calling CoinmarketcapAPI's covert to fiat currency

### DIFF
--- a/raiden_installer/tokens.py
+++ b/raiden_installer/tokens.py
@@ -5,6 +5,7 @@ from decimal import Decimal, getcontext
 
 from raiden_contracts.constants import CONTRACTS_VERSION
 from raiden_installer import network_settings, default_settings
+import requests
 
 Eth_T = TypeVar("Eth_T", int, Decimal, float, str, "Wei")
 Token_T = TypeVar("Token_T")
@@ -106,6 +107,21 @@ class TokenAmount(Generic[Eth_T]):
     @property
     def as_wei(self) -> Wei:
         return Wei(self.value * (10 ** self.currency.decimals))
+
+    @property
+    def as_fiat(self):
+        if not self.value:
+            return 0
+        response = requests.get(
+            'https://pro-api.coinmarketcap.com/v1/tools/price-conversion',
+            params={'symbol': self.ticker, 'amount': self.value, 'convert': 'USD'},
+            headers={
+    	        'Accept': 'application/json',
+    	        'X-CMC_PRO_API_KEY': '30eeec47-754b-4fd1-85c5-a35edf88ff5b'
+            },
+        )
+        result = response.json()
+        return f"{result['data']['quote']['USD']['price']:.3f}"
 
     def __repr__(self):
         return f"{self.value} {self.ticker}"

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -483,7 +483,11 @@ class ConfigurationItemAPIHandler(APIHandler):
 
         def serialize_balance(balance_amount):
             return (
-                {"as_wei": balance_amount.as_wei, "formatted": balance_amount.formatted}
+                {
+                    "as_wei": balance_amount.as_wei,
+                    "formatted": balance_amount.formatted,
+                    "as_fiat": balance_amount.as_fiat
+                }
                 if balance_amount
                 else None
             )

--- a/resources/templates/base.html
+++ b/resources/templates/base.html
@@ -172,14 +172,17 @@
 
            if (balance && balance.ETH && eth_balance_display) {
              eth_balance_display.textContent = balance && balance.ETH.formatted;
+             eth_balance_display.textContent += ` (${balance.ETH.as_fiat} $)`;
            }
 
            if (balance && balance.service_token && service_token_display) {
              service_token_display.textContent = balance && balance.service_token.formatted;
+             service_token_display.textContent += ` (${balance.service_token.as_fiat} $)`;
            }
 
            if (balance && balance.transfer_token && transfer_token_display) {
              transfer_token_display.textContent = balance && balance.transfer_token.formatted;
+             transfer_token_display.textContent += ` (${balance.transfer_token.as_fiat} $)`;
            }
          }
 

--- a/resources/templates/launch.html
+++ b/resources/templates/launch.html
@@ -52,16 +52,17 @@
    let has_enough_service_token = hasEnoughServiceTokenToLaunchRaiden(balance);
    let has_enough_transfer_token = hasEnoughTransferTokenToLaunchRaiden(balance);
 
-
-   eth_balance_display_elem.textContent = balance.ETH.formatted;
+   eth_balance_display_elem.textContent = `${balance.ETH.formatted} (${balance.ETH.as_fiat} $)`;
    eth_balance_display_elem.classList.toggle("ok", has_enough_eth);
    eth_balance_display_elem.classList.toggle("nok", !has_enough_eth);
 
    service_token_balance_display_elem.textContent = (balance.service_token && balance.service_token.formatted) || "N/A";
+   service_token_balance_display_elem.textContent += ` (${balance.service_token.as_fiat} $)`
    service_token_balance_display_elem.classList.toggle("ok", has_enough_service_token);
    service_token_balance_display_elem.classList.toggle("nok", !has_enough_service_token);
 
    transfer_token_balance_display_elem.textContent = (balance.transfer_token && balance.transfer_token.formatted) || "N/A";
+   transfer_token_balance_display_elem.textContent += ` (${balance.transfer_token.as_fiat} $)`
    transfer_token_balance_display_elem.classList.toggle("ok", has_enough_transfer_token);
    transfer_token_balance_display_elem.classList.toggle("nok", !has_enough_transfer_token);
 


### PR DESCRIPTION
Calls Coinmarketcaps APIs to convert the cryptocurrencies to USD. The API key is my personal one need to see if raiden has to have a different key. Unfortunately modify the serverside because Coinmarketcap does not send CORs headers to protect the API keys and also advises to call through the server side of the application.