### PR TITLE
Calling CoinmarketAPI's for currency conversion

### DIFF
--- a/raiden_installer/__init__.py
+++ b/raiden_installer/__init__.py
@@ -29,6 +29,7 @@ class Settings:
     service_token: TokenSettings
     transfer_token: TokenSettings
     routing_mode: str = "pfs"
+    cmc_api_key: str = ""
     monitoring_enabled: bool = True
     # matrix_server and pfs address are only used if client_release_channel = "demo_env"
     matrix_server: str = ""

--- a/raiden_installer/tokens.py
+++ b/raiden_installer/tokens.py
@@ -1,3 +1,4 @@
+import requests
 from dataclasses import dataclass, field, replace
 from decimal import Decimal, getcontext
 from enum import Enum
@@ -106,6 +107,24 @@ class TokenAmount(Generic[Eth_T]):
     @property
     def as_wei(self) -> Wei:
         return Wei(self.value * (10 ** self.currency.decimals))
+
+    @property
+    def as_fiat(self, network_name="mainnet"):
+        if not self.value:
+            return f""
+        response = requests.get(
+            'https://pro-api.coinmarketcap.com/v1/tools/price-conversion',
+            params={'symbol': self.ticker, 'amount': self.value, 'convert': 'USD'},
+            headers={
+    	        'Accept': 'application/json',
+    	        'X-CMC_PRO_API_KEY': network_settings[network_name].cmc_api_key
+            },
+        )
+        if not response.ok:
+            log.info(response.text)
+            return f""
+        result = response.json()
+        return f"{result['data']['quote']['USD']['price']:.3f}"
 
     def __repr__(self):
         return f"{self.value} {self.ticker}"

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -485,7 +485,11 @@ class ConfigurationItemAPIHandler(APIHandler):
 
         def serialize_balance(balance_amount):
             return (
-                {"as_wei": balance_amount.as_wei, "formatted": balance_amount.formatted}
+                {
+                    "as_wei": balance_amount.as_wei,
+                    "formatted": balance_amount.formatted,
+                    "as_fiat": balance_amount.as_fiat    
+                }
                 if balance_amount
                 else None
             )

--- a/resources/conf/mainnet.toml
+++ b/resources/conf/mainnet.toml
@@ -4,6 +4,7 @@ client_release_version = "v0.200.0-rc8"
 services_version = "test"
 ethereum_amount_required = 2e16
 routing_mode = "local"
+cmc_api_key = "30eeec47-754b-4fd1-85c5-a35edf88ff5b"
 
 [service_token]
 ticker = "RDN"

--- a/resources/templates/base.html
+++ b/resources/templates/base.html
@@ -172,14 +172,17 @@
 
            if (balance && balance.ETH && eth_balance_display) {
              eth_balance_display.textContent = balance && balance.ETH.formatted;
+             eth_balance_display.textContent += balance.ETH.as_fiat && ` (${balance.ETH.as_fiat}) $`;
            }
 
            if (balance && balance.service_token && service_token_display) {
              service_token_display.textContent = balance && balance.service_token.formatted;
+             service_token_display.textContent += balance.service_token.as_fiat && ` (${balance.service_token.as_fiat}) $`;
            }
 
            if (balance && balance.transfer_token && transfer_token_display) {
              transfer_token_display.textContent = balance && balance.transfer_token.formatted;
+             transfer_token_display.textContent += balance.transfer_token.as_fiat && ` (${balance.transfer_token.as_fiat}) $`;
            }
          }
 

--- a/resources/templates/base.html
+++ b/resources/templates/base.html
@@ -172,17 +172,17 @@
 
            if (balance && balance.ETH && eth_balance_display) {
              eth_balance_display.textContent = balance && balance.ETH.formatted;
-             eth_balance_display.textContent += balance.ETH.as_fiat && ` (${balance.ETH.as_fiat}) $`;
+             eth_balance_display.textContent += balance.ETH.as_fiat && ` (${balance.ETH.as_fiat} $)`;
            }
 
            if (balance && balance.service_token && service_token_display) {
              service_token_display.textContent = balance && balance.service_token.formatted;
-             service_token_display.textContent += balance.service_token.as_fiat && ` (${balance.service_token.as_fiat}) $`;
+             service_token_display.textContent += balance.service_token.as_fiat && ` (${balance.service_token.as_fiat} $)`;
            }
 
            if (balance && balance.transfer_token && transfer_token_display) {
              transfer_token_display.textContent = balance && balance.transfer_token.formatted;
-             transfer_token_display.textContent += balance.transfer_token.as_fiat && ` (${balance.transfer_token.as_fiat}) $`;
+             transfer_token_display.textContent += balance.transfer_token.as_fiat && ` (${balance.transfer_token.as_fiat} $)`;
            }
          }
 

--- a/resources/templates/launch.html
+++ b/resources/templates/launch.html
@@ -53,15 +53,17 @@
    let has_enough_transfer_token = hasEnoughTransferTokenToLaunchRaiden(balance);
 
 
-   eth_balance_display_elem.textContent = balance.ETH.formatted;
+   eth_balance_display_elem.textContent = balance.ETH.formatted + (balance.ETH.as_fiat && ` (${balance.ETH.as_fiat} $)`);
    eth_balance_display_elem.classList.toggle("ok", has_enough_eth);
    eth_balance_display_elem.classList.toggle("nok", !has_enough_eth);
 
    service_token_balance_display_elem.textContent = (balance.service_token && balance.service_token.formatted) || "N/A";
+   service_token_balance_display_elem.textContent += balance.service_token.as_fiat && ` (${balance.service_token.as_fiat} $)`;
    service_token_balance_display_elem.classList.toggle("ok", has_enough_service_token);
    service_token_balance_display_elem.classList.toggle("nok", !has_enough_service_token);
 
    transfer_token_balance_display_elem.textContent = (balance.transfer_token && balance.transfer_token.formatted) || "N/A";
+   transfer_token_balance_display_elem.textContent += balance.transfer_token.as_fiat && ` (${balance.transfer_token.as_fiat} $)`;
    transfer_token_balance_display_elem.classList.toggle("ok", has_enough_transfer_token);
    transfer_token_balance_display_elem.classList.toggle("nok", !has_enough_transfer_token);
 


### PR DESCRIPTION
Calls Coinmarketcaps APIs to convert the cryptocurrencies to USD. The API key is my personal one need to see if raiden has to have a different key. Unfortunately modify the serverside because Coinmarketcap does not send CORs headers to protect the API keys and also advises to call through the server side of the application.
Ran into merge conflicts with pull request #119 hence opening new pull request.