### PR TITLE
Adds eth_amount_required_after_swap and changes eth_required

### DIFF
--- a/raiden_installer/__init__.py
+++ b/raiden_installer/__init__.py
@@ -29,6 +29,7 @@ class Settings:
     client_release_version: str
     services_version: str
     ethereum_amount_required: int
+    ethereum_amount_required_after_swap: int
     service_token: TokenSettings
     transfer_token: TokenSettings
     routing_mode: str = "pfs"
@@ -63,6 +64,6 @@ def _get_settings(network):
     return Settings(**configuration_data)
 
 
-_NETWORKS = ["goerli", "mainnet"]
+_NETWORKS = ["mainnet"]
 network_settings = {network: _get_settings(network) for network in _NETWORKS}
-default_settings = network_settings["goerli"]
+default_settings = network_settings["mainnet"]

--- a/raiden_installer/token_exchange.py
+++ b/raiden_installer/token_exchange.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from typing import List, Optional
 
+import structlog
 from eth_utils import to_checksum_address
 from web3 import Web3
 
@@ -10,6 +11,8 @@ from raiden_installer.network import Network
 from raiden_installer.tokens import EthereumAmount, TokenAmount, TokenTicker, Wei
 from raiden_installer.uniswap.web3 import contracts as uniswap_contracts
 from raiden_installer.utils import estimate_gas, send_raw_transaction
+
+log = structlog.get_logger()
 
 
 class ExchangeError(Exception):
@@ -22,6 +25,7 @@ class Exchange:
     TRANSFER_WEBSITE_URL: Optional[str] = None
     MAIN_WEBSITE_URL: Optional[str] = None
     TERMS_OF_SERVICE_URL: Optional[str] = None
+    GAS_PRICE_MARGIN = 1.25
 
     def __init__(self, w3: Web3):
         self.w3 = w3
@@ -110,10 +114,12 @@ class Kyber(Exchange):
     def _calculate_transaction_costs(self, token_amount: TokenAmount, account: Account) -> dict:
         exchange_rate = self.get_current_rate(token_amount)
         eth_sold = EthereumAmount(token_amount.value * exchange_rate.value * Decimal(1.2))
-        web3_gas_price = self.w3.eth.generateGasPrice()
+        web3_gas_price = Wei(int(self.w3.eth.generateGasPrice() * self.GAS_PRICE_MARGIN))
+
         kyber_max_gas_price = self.network_contract_proxy.functions.maxGasPrice().call()
         max_gas_price = min(web3_gas_price, kyber_max_gas_price)
         gas_price = EthereumAmount(Wei(max_gas_price))
+        log.debug(f"gas price: {gas_price}")
         token_network_address = self.get_token_network_address(token_amount.ticker)
         transaction_params = {"from": account.address, "value": eth_sold.as_wei}
         eth_address = to_checksum_address(
@@ -134,8 +140,21 @@ class Kyber(Exchange):
             **transaction_params,
         )
 
+        block = self.w3.eth.getBlock(self.w3.eth.blockNumber)
+        max_gas_limit = Wei(int(block["gasLimit"] * 0.9))
+        gas_with_margin = Wei(int(gas * self.GAS_PRICE_MARGIN))
+        gas = max(gas_with_margin, max_gas_limit)
+
+        if max_gas_limit < gas_with_margin:
+            log.debug(
+                f"calculated gas was higher than block's gas limit {max_gas_limit}. Using this limit."
+            )
+
         gas_cost = EthereumAmount(Wei(gas * gas_price.as_wei))
         total = EthereumAmount(gas_cost.value + eth_sold.value)
+
+        log.debug("transaction cost", gas_price=gas_price, gas=gas, eth=eth_sold)
+
         return {
             "gas_price": gas_price,
             "gas": gas,
@@ -144,13 +163,14 @@ class Kyber(Exchange):
             "exchange_rate": exchange_rate,
         }
 
-    def buy_tokens(self, account: Account, token_amount: TokenAmount):
+    def buy_tokens(self, account: Account, token_amount: TokenAmount, transaction_costs=dict()):
         if self.network.name not in self.SUPPORTED_NETWORKS:
             raise ExchangeError(
                 f"{self.name} does not list {token_amount.ticker} on {self.network.name}"
             )
 
-        transaction_costs = self.calculate_transaction_costs(token_amount, account)
+        if not transaction_costs:
+            transaction_costs = self.calculate_transaction_costs(token_amount, account)
         if transaction_costs is None:
             raise ExchangeError("Failed to get transactions costs")
 
@@ -169,7 +189,6 @@ class Kyber(Exchange):
             "gas": gas,
             "value": eth_to_sell.as_wei,
         }
-
         return send_raw_transaction(
             self.w3,
             account,
@@ -224,7 +243,9 @@ class Uniswap(Exchange):
     def _calculate_transaction_costs(self, token_amount: TokenAmount, account: Account) -> dict:
         exchange_rate = self.get_current_rate(token_amount)
         eth_sold = EthereumAmount(token_amount.value * exchange_rate.value)
-        gas_price = EthereumAmount(Wei(self.w3.eth.generateGasPrice()))
+        gas_price = EthereumAmount(
+            Wei(int(self.w3.eth.generateGasPrice() * self.GAS_PRICE_MARGIN))
+        )
         exchange_proxy = self._get_exchange_proxy(token_amount.ticker)
         latest_block = self.w3.eth.getBlock("latest")
         deadline = latest_block.timestamp + self.EXCHANGE_TIMEOUT
@@ -238,6 +259,11 @@ class Uniswap(Exchange):
             deadline,
             **transaction_params,
         )
+
+        block = self.w3.eth.getBlock(self.w3.eth.blockNumber)
+        max_gas_limit = int(block["gasLimit"] * 0.9)
+
+        gas = max(Wei(int(gas * self.GAS_PRICE_MARGIN)), max_gas_limit)
 
         gas_cost = EthereumAmount(Wei(gas * gas_price.as_wei))
         total = EthereumAmount(gas_cost.value + eth_sold.value)

--- a/raiden_installer/tokens.py
+++ b/raiden_installer/tokens.py
@@ -269,6 +269,7 @@ class TokensV37(Enum):
 @dataclass
 class RequiredAmounts:
     eth: EthereumAmount
+    eth_after_swap: EthereumAmount
     service_token: TokenAmount
     transfer_token: TokenAmount
 
@@ -276,6 +277,7 @@ class RequiredAmounts:
     def from_settings(settings):
         return RequiredAmounts(
             eth=EthereumAmount(Wei(settings.ethereum_amount_required)),
+            eth_after_swap=EthereumAmount(Wei(settings.ethereum_amount_required_after_swap)),
             service_token=TokenAmount(
                 Wei(settings.service_token.amount_required),
                 Erc20Token.find_by_ticker(settings.service_token.ticker, settings.network),

--- a/raiden_installer/utils.py
+++ b/raiden_installer/utils.py
@@ -50,7 +50,7 @@ def send_raw_transaction(w3, account, contract_function, *args, **kw):
     transaction_data = result.buildTransaction(transaction_params)
     signed = w3.eth.account.signTransaction(transaction_data, account.private_key)
     tx_hash = w3.eth.sendRawTransaction(signed.rawTransaction)
-
+    log.debug(f"transaction hash: {tx_hash.hex()}")
     return w3.eth.waitForTransactionReceipt(tx_hash, timeout=600)
 
 

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -371,6 +371,7 @@ class BaseRequestHandler(RequestHandler):
             {
                 "network": network,
                 "ethereum_required": required.eth,
+                "ethereum_required_after_swap": required.eth_after_swap,
                 "service_token_required": required.service_token,
                 "transfer_token_required": required.transfer_token,
                 "eip20_abi": json.dumps(EIP20_ABI),

--- a/resources/conf/mainnet.toml
+++ b/resources/conf/mainnet.toml
@@ -2,7 +2,8 @@ network = "mainnet"
 client_release_channel = "testing"
 client_release_version = "v0.200.0-rc8"
 services_version = "test"
-ethereum_amount_required = 2e16
+ethereum_amount_required = 175e15
+ethereum_amount_required_after_swap = 100e15
 routing_mode = "local"
 cmc_api_key = "30eeec47-754b-4fd1-85c5-a35edf88ff5b"
 

--- a/resources/templates/account.html
+++ b/resources/templates/account.html
@@ -36,6 +36,7 @@
 </div>
 {% end %} {% block page_header_scripts %}
 <script type="text/javascript">
+<<<<<<< HEAD
 
  const WEB3_ETH_AMOUNT_ATTRIBUTE = "data-requested-eth-amount";
  const TARGET_ADDRESS = "{{ configuration_file.account.address }}";
@@ -128,6 +129,114 @@
    window.MAIN_VIEW_INTERVAL = 10000;
    window.runMainView();
  });
+=======
+  const WEB3_ETH_AMOUNT_ATTRIBUTE = "data-requested-eth-amount";
+  const TARGET_ADDRESS = "{{ configuration_file.account.address }}";
+
+  async function checkWeb3Network() {
+    let required_chain_id = "{{ configuration_file.network.chain_id }}";
+    await connectWeb3();
+    web3.version.getNetwork(function (error, chain_id) {
+      if (error) {
+        console.error(error);
+      }
+
+      if (chain_id != required_chain_id) {
+        let current_chain_name = CHAIN_ID_MAPPING[chain_id];
+        let required_chain_name = CHAIN_ID_MAPPING[required_chain_id];
+        alert(
+          `Web3 Browser connected to ${current_chain_name}, please change to ${required_chain_name}.`
+        );
+      }
+    });
+  }
+
+  function makeWeb3Transaction(w3, transaction_data) {
+    w3.eth.sendTransaction(transaction_data, function (error, result) {
+      if (result) {
+        // result is the transaction hash
+        trackTransaction(result, "{{ configuration_file.file_name }}");
+      }
+
+      if (error) {
+        console.error(error);
+      }
+    });
+  }
+
+  async function sendEthViaWeb3(wei_to_send) {
+    await checkWeb3Network();
+    let web3 = window.web3;
+    let sender_address =
+      (window.ethereum && window.ethereum.selectedAddress) ||
+      web3.eth.defaultAccount;
+
+    try {
+      eth_station_response = await fetch(
+        "https://ethgasstation.info/api/ethgasAPI.json"
+      ).then((response) => response.json());
+      gas_price = eth_station_response["fast"] * 10e7;
+    } catch {
+      console.err("Could not fetch gas price. Falling back to web3 gas price.");
+    }
+
+    let transaction_data = {
+      from: sender_address,
+      to: TARGET_ADDRESS,
+      value: wei_to_send || ETHEREUM_REQUIRED_AMOUNT,
+    };
+
+    if (gas_price) {
+      transaction_data["gasPrice"] = gas_price;
+    }
+
+    makeWeb3Transaction(web3, transaction_data);
+  }
+
+  async function poll() {
+    let balance = await getBalances(
+      "{{ reverse_url('api-configuration-detail', configuration_file.file_name) }}"
+    );
+
+    if (hasEnoughBalanceToLaunchRaiden(balance)) {
+      let button_send_eth = document.getElementById("btn-web3-eth");
+      button_send_eth.disabled = true;
+      const action = document.querySelector(".action");
+      action.classList.add("tx-received");
+      setTimeout(function () {
+        window.location.href =
+          "{{ reverse_url('swap', configuration_file.file_name, 'RDN') }}";
+      }, 1000);
+    }
+  }
+
+  function main() {
+    poll();
+  }
+
+  window.addEventListener("load", function () {
+    let has_web3 = Boolean(window.ethereum || window.web3);
+    let button_send_eth = document.getElementById("btn-web3-eth");
+
+    button_send_eth.disabled = !has_web3;
+
+    window.MAIN_VIEW_INTERVAL = 10000;
+    window.runMainView();
+  });
+
+  window.addEventListener("load", function () {
+    let account_div_elem = document.querySelector(
+      ".tooltip > .action-copy-paste"
+    );
+    let account_private_key_elem = account_div_elem.querySelector(
+      "span.private"
+    );
+
+    account_div_elem.addEventListener("click", function (evt) {
+      copyToClipboard(account_div_elem, account_private_key_elem);
+    });
+  });
+>>>>>>> bug fixes
 </script>
 
 {% end %}

--- a/resources/templates/account.html
+++ b/resources/templates/account.html
@@ -36,7 +36,6 @@
 </div>
 {% end %} {% block page_header_scripts %}
 <script type="text/javascript">
-<<<<<<< HEAD
 
  const WEB3_ETH_AMOUNT_ATTRIBUTE = "data-requested-eth-amount";
  const TARGET_ADDRESS = "{{ configuration_file.account.address }}";
@@ -129,114 +128,6 @@
    window.MAIN_VIEW_INTERVAL = 10000;
    window.runMainView();
  });
-=======
-  const WEB3_ETH_AMOUNT_ATTRIBUTE = "data-requested-eth-amount";
-  const TARGET_ADDRESS = "{{ configuration_file.account.address }}";
-
-  async function checkWeb3Network() {
-    let required_chain_id = "{{ configuration_file.network.chain_id }}";
-    await connectWeb3();
-    web3.version.getNetwork(function (error, chain_id) {
-      if (error) {
-        console.error(error);
-      }
-
-      if (chain_id != required_chain_id) {
-        let current_chain_name = CHAIN_ID_MAPPING[chain_id];
-        let required_chain_name = CHAIN_ID_MAPPING[required_chain_id];
-        alert(
-          `Web3 Browser connected to ${current_chain_name}, please change to ${required_chain_name}.`
-        );
-      }
-    });
-  }
-
-  function makeWeb3Transaction(w3, transaction_data) {
-    w3.eth.sendTransaction(transaction_data, function (error, result) {
-      if (result) {
-        // result is the transaction hash
-        trackTransaction(result, "{{ configuration_file.file_name }}");
-      }
-
-      if (error) {
-        console.error(error);
-      }
-    });
-  }
-
-  async function sendEthViaWeb3(wei_to_send) {
-    await checkWeb3Network();
-    let web3 = window.web3;
-    let sender_address =
-      (window.ethereum && window.ethereum.selectedAddress) ||
-      web3.eth.defaultAccount;
-
-    try {
-      eth_station_response = await fetch(
-        "https://ethgasstation.info/api/ethgasAPI.json"
-      ).then((response) => response.json());
-      gas_price = eth_station_response["fast"] * 10e7;
-    } catch {
-      console.err("Could not fetch gas price. Falling back to web3 gas price.");
-    }
-
-    let transaction_data = {
-      from: sender_address,
-      to: TARGET_ADDRESS,
-      value: wei_to_send || ETHEREUM_REQUIRED_AMOUNT,
-    };
-
-    if (gas_price) {
-      transaction_data["gasPrice"] = gas_price;
-    }
-
-    makeWeb3Transaction(web3, transaction_data);
-  }
-
-  async function poll() {
-    let balance = await getBalances(
-      "{{ reverse_url('api-configuration-detail', configuration_file.file_name) }}"
-    );
-
-    if (hasEnoughBalanceToLaunchRaiden(balance)) {
-      let button_send_eth = document.getElementById("btn-web3-eth");
-      button_send_eth.disabled = true;
-      const action = document.querySelector(".action");
-      action.classList.add("tx-received");
-      setTimeout(function () {
-        window.location.href =
-          "{{ reverse_url('swap', configuration_file.file_name, 'RDN') }}";
-      }, 1000);
-    }
-  }
-
-  function main() {
-    poll();
-  }
-
-  window.addEventListener("load", function () {
-    let has_web3 = Boolean(window.ethereum || window.web3);
-    let button_send_eth = document.getElementById("btn-web3-eth");
-
-    button_send_eth.disabled = !has_web3;
-
-    window.MAIN_VIEW_INTERVAL = 10000;
-    window.runMainView();
-  });
-
-  window.addEventListener("load", function () {
-    let account_div_elem = document.querySelector(
-      ".tooltip > .action-copy-paste"
-    );
-    let account_private_key_elem = account_div_elem.querySelector(
-      "span.private"
-    );
-
-    account_div_elem.addEventListener("click", function (evt) {
-      copyToClipboard(account_div_elem, account_private_key_elem);
-    });
-  });
->>>>>>> bug fixes
 </script>
 
 {% end %}

--- a/resources/templates/base.html
+++ b/resources/templates/base.html
@@ -9,6 +9,7 @@
          const SERVICE_TOKEN_REQUIRED_AMOUNT = parseInt("{{ service_token_required.as_wei }}");
          const TRANSFER_TOKEN_REQUIRED_AMOUNT = parseInt("{{ transfer_token_required.as_wei }}");
          const ETHEREUM_REQUIRED_AMOUNT = parseInt("{{ ethereum_required.as_wei }}");
+         const ETHEREUM_REQUIRED_AMOUNT_AFTER_SWAP = parseInt("{{ ethereum_required_after_swap.as_wei }}");
          const CHAIN_ID_MAPPING = {
            1: "Mainnet",
            3: "Ropsten",
@@ -88,7 +89,7 @@
          }
 
          function hasEnoughEthToLaunchRaiden(balance) {
-           return (balance && balance.ETH && balance.ETH.as_wei >= ETHEREUM_REQUIRED_AMOUNT);
+           return (balance && balance.ETH && balance.ETH.as_wei >= ETHEREUM_REQUIRED_AMOUNT_AFTER_SWAP);
          }
 
          function hasEnoughServiceTokenToLaunchRaiden(balance) {


### PR DESCRIPTION
Fixes #142

Replaces the old eth_required_amount with two new thresholds. One ETH threshold (`eth_required`) to execute the swaps and on ETH threshold (`eth_required_after_swap`) to start Raiden