### PR TITLE
remove app bundle for mac

### DIFF
--- a/tools/pyinstaller/raiden_webapp.spec
+++ b/tools/pyinstaller/raiden_webapp.spec
@@ -65,9 +65,3 @@ exe = EXE(
     console=True,
 )
 
-if sys.platform == "darwin":
-    app = BUNDLE(
-        exe,
-        name="Raiden Wizard.app",
-        icon="./raiden_installer/web/static/icons/raiden_wizard_macOS_icon.icns",
-    )


### PR DESCRIPTION
As long as their is no own window application for the wizard it should not be bundled as an app for mac builds. Otherwise there will be no terminal open to shut down the wizard which would make it very hard for non-technical users to do so.