### PR TITLE
Merge UDC into RDN Swap, make transactions faster

### DIFF
--- a/raiden_installer/constants.py
+++ b/raiden_installer/constants.py
@@ -1,0 +1,11 @@
+import sys
+
+# web3 constants
+GAS_PRICE_MARGIN = 1.35
+GAS_LIMIT_MARGIN = 1.25
+
+MAX_INT = sys.maxsize
+
+# 3rd party urls
+
+ETH_GAS_STATION_API = "https://ethgasstation.info/api/ethgasAPI.json"

--- a/raiden_installer/ethereum_rpc.py
+++ b/raiden_installer/ethereum_rpc.py
@@ -1,17 +1,43 @@
 from re import search
 from urllib.parse import urlparse
 
+import requests
+import structlog
 from web3 import HTTPProvider, Web3
-from web3.gas_strategies.time_based import fast_gas_price_strategy
+from web3.gas_strategies.time_based import construct_time_based_gas_price_strategy
 from web3.middleware import construct_sign_and_send_raw_middleware, geth_poa_middleware
+from web3.types import Wei
 
 from raiden_installer.account import Account
+from raiden_installer.constants import ETH_GAS_STATION_API, GAS_PRICE_MARGIN
 from raiden_installer.network import Network
+
+log = structlog.get_logger()
 
 
 def make_web3_provider(url: str, account: Account) -> Web3:
     w3 = Web3(HTTPProvider(url))
-    w3.eth.setGasPriceStrategy(fast_gas_price_strategy)
+
+    def gas_price_strategy_eth_gas_station_or_with_margin(web3: Web3, transaction_params):
+        # FIXME: This is a temporary fix to speed up gas price generation
+        # by fetching from eth_gas_station if possible.
+        # Once we have a reliable gas price calculation this can be removed
+        try:
+            response = requests.get(ETH_GAS_STATION_API)
+            if response and response.status_code == 200:
+                data = response.json()
+                return Wei(int(data["fast"] * 10e7))
+        except (TimeoutError, ConnectionError, KeyError):
+            log.debug("Could not fetch from ethgasstation. Falling back to web3 gas estimation.")
+
+        gas_price_strategy = construct_time_based_gas_price_strategy(
+            max_wait_seconds=60, sample_size=25
+        )
+        gas_price = Wei(int(gas_price_strategy(web3, transaction_params) * GAS_PRICE_MARGIN))
+        return gas_price
+
+    w3.eth.setGasPriceStrategy(gas_price_strategy_eth_gas_station_or_with_margin)
+
     if account.passphrase is not None:
         w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account.private_key))
     w3.middleware_onion.inject(geth_poa_middleware, layer=0)

--- a/raiden_installer/transactions.py
+++ b/raiden_installer/transactions.py
@@ -5,13 +5,12 @@ from web3 import Web3
 from raiden_contracts.constants import CONTRACT_CUSTOM_TOKEN, CONTRACT_USER_DEPOSIT
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
 from raiden_installer.account import Account
-from raiden_installer.tokens import Erc20Token, EthereumAmount, TokenAmount, Wei
-from raiden_installer.utils import get_contract_address, send_raw_transaction
+from raiden_installer.tokens import Erc20Token, TokenAmount, Wei
+from raiden_installer.utils import get_contract_address, send_raw_transaction, wait_for_transaction
 
 GAS_REQUIRED_FOR_DEPOSIT: int = 200_000
 GAS_REQUIRED_FOR_APPROVE: int = 70_000
 GAS_REQUIRED_FOR_MINT: int = 100_000
-GAS_PRICE_MARGIN: float = 1.25
 
 
 def _make_deposit_proxy(w3: Web3, token: Erc20Token):
@@ -45,39 +44,14 @@ def mint_tokens(w3: Web3, account: Account, token: Erc20Token):
 
 
 def deposit_service_tokens(w3: Web3, account: Account, token: Erc20Token, amount: Wei):
-    token_proxy = _make_token_proxy(w3=w3, token=token)
     deposit_proxy = _make_deposit_proxy(w3=w3, token=token)
-
     current_deposit_amount = TokenAmount(
         Wei(deposit_proxy.functions.total_deposit(account.address).call()), token
     )
-
-    gas_price = Wei(int(w3.eth.generateGasPrice() * GAS_PRICE_MARGIN))
     new_deposit_amount = TokenAmount(amount, token)
     total_deposit = current_deposit_amount + new_deposit_amount
-    nonce = w3.eth.getTransactionCount(account.address)
 
-    send_raw_transaction(
-        w3,
-        account,
-        token_proxy.functions.approve,
-        deposit_proxy.address,
-        0,
-        gas=GAS_REQUIRED_FOR_APPROVE,
-        gas_price=gas_price,
-        nonce=nonce,
-    )
-
-    send_raw_transaction(
-        w3,
-        account,
-        token_proxy.functions.approve,
-        deposit_proxy.address,
-        total_deposit.as_wei,
-        gas=GAS_REQUIRED_FOR_APPROVE,
-        gas_price=gas_price,
-        nonce=nonce + 1,
-    )
+    approve(w3, account, deposit_proxy.address, total_deposit.as_wei, token)
 
     return send_raw_transaction(
         w3,
@@ -86,9 +60,37 @@ def deposit_service_tokens(w3: Web3, account: Account, token: Erc20Token, amount
         account.address,
         total_deposit.as_wei,
         gas=GAS_REQUIRED_FOR_DEPOSIT,
-        gas_price=gas_price,
-        nonce=nonce + 2,
     )
+
+
+def approve(w3, account, allowed_address, allowance: Wei, token: Erc20Token):
+    token_proxy = _make_token_proxy(w3=w3, token=token)
+    old_allowance = token_proxy.functions.allowance(account.address, allowed_address).call()
+    nonce = w3.eth.getTransactionCount(account.address)
+
+    if old_allowance > 0:
+        send_raw_transaction(
+            w3,
+            account,
+            token_proxy.functions.approve,
+            allowed_address,
+            0,
+            gas=GAS_REQUIRED_FOR_APPROVE,
+            nonce=nonce,
+        )
+        nonce += 1
+
+    transaction_receipt = send_raw_transaction(
+        w3,
+        account,
+        token_proxy.functions.approve,
+        allowed_address,
+        allowance,
+        gas=GAS_REQUIRED_FOR_APPROVE,
+        nonce=nonce,
+    )
+
+    wait_for_transaction(w3, transaction_receipt)
 
 
 def get_token_balance(w3: Web3, account: Account, token: Erc20Token) -> TokenAmount:


### PR DESCRIPTION
This PR focusses mainly on the reduction of the waiting time for the user. Several optimizations have been made. 

## Move UDC deposit into RDN swap
To make it more convinient for the user the RDN tokens will directly be sent to the UDC after swapping ETH to RDN. This happens automatically while the user is waiting for the swap to be done. After the succesful RDN swap the RDNs are already stored in the UDC.

## Improve gas estimation 
I wrote my own gas price strategy which simply takes only 25 blocks instead of 120 to calculate the price from. This reduces buildung the transaction from ~1 minuten down to 16 seconds. Additionally for the short term I included fetching the gas price from ethgasstion. This is done in a matter of milliseconds. As a fallback my own gas price strategy including a margin of 35% is used. 

## Do not set allowance to 0 if it is already
I also included @palango s PR in this PR and removed the little bugs. 


## result
The whole process runs much faster now. The only time where the user has to wait for a long time is when raiden is being synced. 

fixes #181 , 