### PR TITLE
Some drive by fixes

### DIFF
--- a/raiden_installer/account.py
+++ b/raiden_installer/account.py
@@ -16,6 +16,7 @@ from web3 import Web3
 
 from raiden_installer import log
 from raiden_installer.tokens import ETH, TokenAmount, Wei
+from raiden_installer.constants import WEB3_TIMEOUT
 
 
 def make_random_string(length=32):
@@ -51,7 +52,7 @@ class Account:
         return TokenAmount(Wei(w3.eth.getBalance(self.address)), ETH)
 
     def wait_for_ethereum_funds(
-        self, w3: Web3, expected_amount: TokenAmount, timeout: int = 300
+        self, w3: Web3, expected_amount: TokenAmount, timeout: int = WEB3_TIMEOUT
     ) -> TokenAmount:
         time_remaining = timeout
         POLLING_INTERVAL = 1

--- a/raiden_installer/constants.py
+++ b/raiden_installer/constants.py
@@ -1,6 +1,7 @@
 import sys
 
 # web3 constants
+WEB3_TIMEOUT = 300
 GAS_PRICE_MARGIN = 1.35
 GAS_LIMIT_MARGIN = 1.25
 

--- a/raiden_installer/raiden.py
+++ b/raiden_installer/raiden.py
@@ -32,7 +32,7 @@ def temporary_passphrase_file(passphrase):
         passfile.flush()
         yield passphrase_file_path
     finally:
-        for i in range(5):
+        for _ in range(5):
             passfile.seek(0)
             passfile.write(os.urandom(1024).hex())
             passfile.flush()

--- a/raiden_installer/token_exchange.py
+++ b/raiden_installer/token_exchange.py
@@ -61,7 +61,9 @@ class Exchange:
     def _calculate_transaction_costs(self, token_amount: TokenAmount, account: Account) -> dict:
         raise NotImplementedError
 
-    def buy_tokens(self, account: Account, token_amount: TokenAmount, transaction_costs=dict()):
+    def buy_tokens(self, account: Account, token_amount: TokenAmount, transaction_costs=None):
+        if transaction_costs is None:
+            transaction_costs = dict()
         raise NotImplementedError
 
     def is_listing_token(self, ticker: TokenTicker):
@@ -153,7 +155,8 @@ class Kyber(Exchange):
         log.debug("Gas Limit", gas_with_margin=gas_with_margin, max_gas_limit=max_gas_limit)
         if max_gas_limit < gas_with_margin:
             log.debug(
-                f"calculated gas was higher than block's gas limit {max_gas_limit}. Using this limit."
+                f"calculated gas was higher than block's gas limit {max_gas_limit}. "
+                "Using this limit."
             )
 
         gas_cost = EthereumAmount(Wei(gas * gas_price.as_wei))
@@ -169,7 +172,9 @@ class Kyber(Exchange):
             "exchange_rate": exchange_rate,
         }
 
-    def buy_tokens(self, account: Account, token_amount: TokenAmount, transaction_costs=dict()):
+    def buy_tokens(self, account: Account, token_amount: TokenAmount, transaction_costs=None):
+        if transaction_costs is None:
+            transaction_costs = dict()
         if self.network.name not in self.SUPPORTED_NETWORKS:
             raise ExchangeError(
                 f"{self.name} does not list {token_amount.ticker} on {self.network.name}"
@@ -279,10 +284,11 @@ class Uniswap(Exchange):
             "exchange_rate": exchange_rate,
         }
 
-    def buy_tokens(self, account: Account, token_amount: TokenAmount, transaction_costs=dict()):
-        if transaction_costs:
+    def buy_tokens(self, account: Account, token_amount: TokenAmount, transaction_costs=None):
+        if transaction_costs is not None:
             costs = transaction_costs
         else:
+            transaction_costs = dict()
             costs = self.calculate_transaction_costs(token_amount, account)
 
         if costs is None:

--- a/raiden_installer/token_exchange.py
+++ b/raiden_installer/token_exchange.py
@@ -6,7 +6,7 @@ from eth_utils import to_checksum_address
 from web3 import Web3
 
 from raiden_installer.account import Account
-from raiden_installer.constants import GAS_LIMIT_MARGIN
+from raiden_installer.constants import GAS_LIMIT_MARGIN, WEB3_TIMEOUT
 from raiden_installer.kyber.web3 import contracts as kyber_contracts, tokens as kyber_tokens
 from raiden_installer.network import Network
 from raiden_installer.tokens import EthereumAmount, TokenAmount, TokenTicker, Wei
@@ -215,7 +215,7 @@ class Uniswap(Exchange):
     RAIDEN_EXCHANGE_ADDRESSES = {"mainnet": "0x7D03CeCb36820b4666F45E1b4cA2538724Db271C"}
     DAI_EXCHANGE_ADDRESSES = {"mainnet": "0x2a1530C4C41db0B0b2bB646CB5Eb1A67b7158667"}
     EXCHANGE_FEE = 0.003
-    EXCHANGE_TIMEOUT = 20 * 60  # maximum waiting time in seconds
+    EXCHANGE_TIMEOUT = WEB3_TIMEOUT  # maximum waiting time in seconds
     TRANSFER_WEBSITE_URL = "https://uniswap.ninja/send"
     MAIN_WEBSITE_URL = "https://uniswap.io"
     TERMS_OF_SERVICE_URL = "https://uniswap.io"

--- a/raiden_installer/utils.py
+++ b/raiden_installer/utils.py
@@ -6,7 +6,7 @@ from web3 import Web3
 
 from raiden_contracts.contract_manager import get_contracts_deployment_info
 from raiden_installer import log
-from raiden_installer.constants import GAS_PRICE_MARGIN
+from raiden_installer.constants import WEB3_TIMEOUT
 from raiden_installer.tokens import EthereumAmount, Wei
 
 
@@ -56,7 +56,7 @@ def send_raw_transaction(w3, account, contract_function, *args, **kw):
     signed = w3.eth.account.signTransaction(transaction_data, account.private_key)
     tx_hash = w3.eth.sendRawTransaction(signed.rawTransaction)
     log.debug(f"transaction hash: {tx_hash.hex()}")
-    return w3.eth.waitForTransactionReceipt(tx_hash, timeout=600)
+    return w3.eth.waitForTransactionReceipt(tx_hash, timeout=WEB3_TIMEOUT)
 
 
 def wait_for_transaction(web3: Web3, transaction_receipt: Dict[str, Any]) -> None:

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -357,7 +357,8 @@ class AsyncTaskHandler(WebSocketHandler):
                 elif service_token_balance.as_wei > 0:
 
                     self._send_status_update(
-                        f"Making deposit of {service_token_balance.formatted} to the User Deposit Contract"
+                        f"Making deposit of {service_token_balance.formatted} to the "
+                        "User Deposit Contract"
                     )
                     self._send_status_update(f"This might take a few minutes")
                     transaction_receipt = deposit_service_tokens(
@@ -384,7 +385,9 @@ class AsyncTaskHandler(WebSocketHandler):
                     redirect_url = self.reverse_url("launch", configuration_file.file_name)
                     next_page = "You are ready to launch Raiden! ..."
 
-                self._send_summary(["Congratulations! Swap Successful!", next_page], icon=token_ticker)
+                self._send_summary(
+                    ["Congratulations! Swap Successful!", next_page], icon=token_ticker
+                )
                 time.sleep(5)
                 self._send_redirect(redirect_url)
             else:
@@ -408,7 +411,7 @@ class AsyncTaskHandler(WebSocketHandler):
             configuration_file = RaidenConfigurationFile.get_by_filename(configuration_file_name)
             account = configuration_file.account
             w3 = make_web3_provider(configuration_file.ethereum_client_rpc_endpoint, account)
-            self._send_txhash_message(["Waiting for confirmation of transaction"], tx_hash= tx_hash)
+            self._send_txhash_message(["Waiting for confirmation of transaction"], tx_hash=tx_hash)
 
             transaction_found = False
             iteration_cycle = 0

--- a/tools/empty_wizard_accounts.py
+++ b/tools/empty_wizard_accounts.py
@@ -130,6 +130,7 @@ class AccountDrainer:
                 f"\tUDC: {udc_balance}\n"
             )
             self.accounts_with_balance.append(address)
+            self.accounts_with_balance = list(set(self.accounts_with_balance))
 
     def unlock_accounts_with_balance(self):
         known_passwords = set()
@@ -174,11 +175,13 @@ class AccountDrainer:
 
     def work_left(self):
         if any(not self.udc_empty(address) for address in self.accounts_with_balance):
+            print(f"Draining UDC")
             return True
         for address in self.accounts_with_balance:
             if address.lower() == self.receiver.lower():
                 continue
             if self.has_any_balance_left(address):
+                print(f"continuing to drain {address}:")
                 return True
         return False
 


### PR DESCRIPTION
This is a small collection of improvements / fixes that I did while pursuing #209 

- There are a couple of places that use timeouts with web3 requests. I added a single constant for the backend for the timeout values.
- A tiny fix to the `tools./empty_wizard_accounts.py` script: due to an iteration over an expanding list, the script never terminated.
- Some PEP8/black style fixes.