### PR TITLE
Docker build to create a binary for debian-stretch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+help:
+	@echo "bundle-docker - create standalone executable with PyInstaller via a docker container"
+
+
+bundle-docker:
+	docker build -t pyinstallerbuilder -f tools/docker/build.Dockerfile .
+	-(docker rm builder)
+	docker create --name builder pyinstallerbuilder
+	mkdir -p dist/
+	docker cp builder:/raiden-wizard/raiden_wizard_linux.tar.gz dist/raiden_wizard_linux.tar.gz
+	docker rm builder

--- a/tools/docker/build.Dockerfile
+++ b/tools/docker/build.Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.7-stretch
+
+# install dependencies
+RUN apt-get update
+RUN apt-get install -y git-core wget xz-utils build-essential automake pkg-config libtool libffi-dev python3-dev libgmp-dev
+
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+
+
+ADD ./requirements.txt /tmp
+WORKDIR /tmp
+
+RUN pip install -r requirements.txt
+
+ADD . /raiden-wizard
+WORKDIR /raiden-wizard
+
+# build pyinstaller package
+RUN pyinstaller --noconfirm --clean tools/pyinstaller/raiden_webapp.spec
+
+# pack result to have a unique name to get it out of the container later
+RUN cd dist && \
+    tar -cvzf ./raiden_wizard_linux.tar.gz raiden_wizard && \
+    mv raiden_wizard_linux.tar.gz ..


### PR DESCRIPTION
This PR includes a docker build and make command to create a wizard binary built on debian-stretch base. This is the linux version which is supported by raiden also.

To create the binary just run: 

`make bundle-docker` 

You are gonna find in directory `dist` a tar called `raiden_wizard_linux.tar.gz` containing an executable.

Now, the enduser does not need to mark the binary as executable anymore and just run it