### PR TITLE
Configure build to output one binary for mainnet and one for goerli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,24 @@ clean:
 	rm -r build/ dist/
 
 bundle-docker:
+	mkdir -p dist/
+	# build for mainnet
 	docker build -t pyinstallerbuilder -f tools/docker/build.Dockerfile .
 	-(docker rm builder)
 	docker create --name builder pyinstallerbuilder
-	mkdir -p dist/
-	docker cp builder:/raiden-wizard/raiden_wizard_linux.tar.gz dist/raiden_wizard_linux.tar.gz
+	docker cp builder:/raiden-wizard/raiden_wizard_linux.tar.gz dist/raiden_wizard_mainnet_linux.tar.gz
 	docker rm builder
+	# build for goerli
+	docker build --build-arg RAIDEN_INSTALLER_BUILD_ENTRY_SCRIPT="web_testnet.py" -t pyinstallerbuilder_goerli -f tools/docker/build.Dockerfile .
+	-(docker rm builder_goerli)
+	docker create --name builder_goerli pyinstallerbuilder_goerli
+	docker cp builder_goerli:/raiden-wizard/raiden_wizard_linux.tar.gz dist/raiden_wizard_goerli_linux.tar.gz
+	docker rm builder_goerli
 
 build-mac: clean
 	pyinstaller --noconfirm --clean tools/pyinstaller/raiden_webapp.spec
-	tar -czf raiden_wizard_macOS-1.0.x.tar.gz dist/raiden_wizard
+	tar -czf raiden_wizard_mainnet_macOS-1.0.x.tar.gz dist/raiden_wizard
+	rm dist/raiden_wizard
+	RAIDEN_INSTALLER_BUILD_ENTRY_SCRIPT="web_testnet.py" pyinstaller --noconfirm --clean tools/pyinstaller/raiden_webapp.spec
+	tar -czf raiden_wizard_goerli_macOS-1.0.x.tar.gz dist/raiden_wizard
+	rm dist/raiden_wizard

--- a/tools/docker/build.Dockerfile
+++ b/tools/docker/build.Dockerfile
@@ -17,6 +17,10 @@ RUN pip install -r requirements.txt && pip install "PyInstaller==3.5"
 ADD . /raiden-wizard
 WORKDIR /raiden-wizard
 
+ARG RAIDEN_INSTALLER_BUILD_ENTRY_SCRIPT=web.py
+
+ENV RAIDEN_INSTALLER_BUILD_ENTRY_SCRIPT=${RAIDEN_INSTALLER_BUILD_ENTRY_SCRIPT}
+
 # build pyinstaller package
 RUN pyinstaller --noconfirm --clean tools/pyinstaller/raiden_webapp.spec
 

--- a/tools/pyinstaller/raiden_webapp.spec
+++ b/tools/pyinstaller/raiden_webapp.spec
@@ -19,8 +19,10 @@ RESOURCE_FOLDER = os.path.abspath(os.path.join(ROOT_FOLDER, "resources"))
 
 HOOKS_FOLDER = os.path.join(PWD, "hooks")
 
+ENTRY_SCRIPT = os.getenv("RAIDEN_INSTALLER_BUILD_ENTRY_SCRIPT", "web.py")
+
 a = Analysis(
-    [os.path.join(ROOT_FOLDER, "raiden_installer", "web.py")],
+    [os.path.join(ROOT_FOLDER, "raiden_installer", ENTRY_SCRIPT)],
     pathex=[os.path.join(ROOT_FOLDER, "raiden_installer")],
     binaries=[],
     datas=[(RESOURCE_FOLDER, "resources")],


### PR DESCRIPTION
We decided to have separate binaries for the two versions of the Wizard.