### PR TITLE
Use demoenv for testnet wizard

### DIFF
--- a/raiden_installer/__init__.py
+++ b/raiden_installer/__init__.py
@@ -65,4 +65,3 @@ def _get_settings(settings_name):
 
 _SETTINGS = ["mainnet", "demo_env"]
 available_settings = {settings_name: _get_settings(settings_name) for settings_name in _SETTINGS}
-default_settings = available_settings["mainnet"]

--- a/raiden_installer/__init__.py
+++ b/raiden_installer/__init__.py
@@ -63,6 +63,6 @@ def _get_settings(network):
     return Settings(**configuration_data)
 
 
-_NETWORKS = ["mainnet", "goerli"]
-network_settings = {network: _get_settings(network) for network in _NETWORKS}
-default_settings = network_settings["mainnet"]
+_SETTINGS = ["mainnet", "goerli"]
+available_settings = {network: _get_settings(network) for network in _SETTINGS}
+default_settings = available_settings["mainnet"]

--- a/raiden_installer/__init__.py
+++ b/raiden_installer/__init__.py
@@ -49,8 +49,8 @@ def get_resource_folder_path():
     return os.path.join(root_folder, "resources")
 
 
-def _get_settings(network):
-    configuration_file = os.path.join(get_resource_folder_path(), "conf", f"{network}.toml")
+def _get_settings(settings_name):
+    configuration_file = os.path.join(get_resource_folder_path(), "conf", f"{settings_name}.toml")
     configuration_data = toml.load(configuration_file)
 
     service_token_settings = TokenSettings(**configuration_data["service_token"])
@@ -63,6 +63,6 @@ def _get_settings(network):
     return Settings(**configuration_data)
 
 
-_SETTINGS = ["mainnet", "goerli"]
-available_settings = {network: _get_settings(network) for network in _SETTINGS}
+_SETTINGS = ["mainnet", "demo_env"]
+available_settings = {settings_name: _get_settings(settings_name) for settings_name in _SETTINGS}
 default_settings = available_settings["mainnet"]

--- a/raiden_installer/base.py
+++ b/raiden_installer/base.py
@@ -65,12 +65,14 @@ class RaidenConfigurationFile:
         }
 
         # If the config is for a demo-env we'll need to add/overwrite some settings
-        if self.settings.client_release_channel == "demo_env":  # noqa
-            base_config.update({"matrix-server": self.settings.matrix_server})  # noqa
-            base_config["routing-mode"] = "pfs"
-            base_config[
-                "pathfinding-service-address"
-            ] = self.settings.pathfinding_service_address  # noqa
+        if self.settings.client_release_channel == "demo_env":
+            base_config.update(
+                {
+                    "matrix-server": self.settings.matrix_server,
+                    "routing-mode": "pfs",
+                    "pathfinding-service-address": self.settings.pathfinding_service_address,
+                }
+            )
 
         return base_config
 

--- a/raiden_installer/network.py
+++ b/raiden_installer/network.py
@@ -3,8 +3,6 @@ import uuid
 
 import requests
 
-from raiden_installer import default_settings
-
 
 class FundingError(Exception):
     pass
@@ -57,10 +55,6 @@ class Network:
             "kovan": Kovan,
         }.get(name, Network)
         return network_class()
-
-    @staticmethod
-    def get_default():
-        return Network.get_by_name(default_settings.network)
 
 
 class Mainnet(Network):

--- a/raiden_installer/raiden.py
+++ b/raiden_installer/raiden.py
@@ -20,7 +20,7 @@ import psutil
 import requests
 from requests.exceptions import ConnectionError
 
-from raiden_installer import default_settings, log, network_settings
+from raiden_installer import Settings, default_settings, log
 
 
 @contextmanager
@@ -393,8 +393,7 @@ class RaidenClient:
         return cls._make_release(response.json())
 
     @staticmethod
-    def get_client(network_name=None):
-        settings = network_settings[network_name] if network_name else default_settings
+    def get_client(settings: Settings):
         raiden_class = {
             "testing": RaidenTestnetRelease,
             "mainnet": RaidenRelease,
@@ -516,12 +515,12 @@ class RaidenNightly(RaidenClient):
 class RaidenDemoEnv(RaidenTestnetRelease):
     @property
     def routing_mode(self):
-        return settings.routing_mode  # noqa
+        return default_settings.routing_mode  # noqa
 
     @property
     def matrix_server(self):
-        return settings.matrix_server  # noqa
+        return default_settings.matrix_server  # noqa
 
     @property
     def pathfinding_service_address(self):
-        return settings.pathfinding_service_address  # noqa
+        return default_settings.pathfinding_service_address  # noqa

--- a/raiden_installer/raiden.py
+++ b/raiden_installer/raiden.py
@@ -20,7 +20,7 @@ import psutil
 import requests
 from requests.exceptions import ConnectionError
 
-from raiden_installer import Settings, default_settings, log
+from raiden_installer import Settings, log
 
 
 @contextmanager

--- a/raiden_installer/raiden.py
+++ b/raiden_installer/raiden.py
@@ -398,7 +398,7 @@ class RaidenClient:
             "testing": RaidenTestnetRelease,
             "mainnet": RaidenRelease,
             "nightly": RaidenNightly,
-            "demo_env": RaidenDemoEnv,
+            "demo_env": RaidenTestnetRelease,
         }[settings.client_release_channel]
         return raiden_class.make_by_tag(settings.client_release_version)
 
@@ -510,17 +510,3 @@ class RaidenNightly(RaidenClient):
                 releases.append(cls._make_release(**params))
 
         return releases
-
-
-class RaidenDemoEnv(RaidenTestnetRelease):
-    @property
-    def routing_mode(self):
-        return default_settings.routing_mode  # noqa
-
-    @property
-    def matrix_server(self):
-        return default_settings.matrix_server  # noqa
-
-    @property
-    def pathfinding_service_address(self):
-        return default_settings.pathfinding_service_address  # noqa

--- a/raiden_installer/shared_handlers.py
+++ b/raiden_installer/shared_handlers.py
@@ -15,7 +15,7 @@ from wtforms.validators import EqualTo
 from wtforms_tornado import Form
 
 from raiden_contracts.contract_manager import ContractManager, contracts_precompiled_path
-from raiden_installer import available_settings, default_settings, log
+from raiden_installer import available_settings, log
 from raiden_installer.base import Account, RaidenConfigurationFile
 from raiden_installer.ethereum_rpc import EthereumRPCProvider, Infura, make_web3_provider
 from raiden_installer.network import Network
@@ -33,7 +33,6 @@ EIP20_ABI = ContractManager(contracts_precompiled_path()).get_contract_abi("Stan
 PASSPHRASE: Optional[str] = None
 
 AVAILABLE_NETWORKS = [Network.get_by_name(n) for n in ["mainnet", "ropsten", "goerli"]]
-DEFAULT_NETWORK = Network.get_default()
 
 
 def try_unlock(account):
@@ -42,10 +41,7 @@ def try_unlock(account):
 
 
 class QuickSetupForm(Form):
-    network = wtforms.HiddenField("Network", default=DEFAULT_NETWORK.name)
-    use_rsb = wtforms.HiddenField(
-        "Use Raiden Service Bundle", default=default_settings.monitoring_enabled
-    )
+    network = wtforms.HiddenField("Network")
     endpoint = wtforms.StringField("Infura Project ID/RPC Endpoint")
 
     def validate_network(self, field):
@@ -194,8 +190,8 @@ class AsyncTaskHandler(WebSocketHandler):
                 account.keystore_file_path,
                 self.installer_settings_name,
                 ethereum_rpc_provider.url,
-                routing_mode="pfs" if form.data["use_rsb"] else "local",
-                enable_monitoring=form.data["use_rsb"],
+                routing_mode=self.installer_settings.routing_mode,
+                enable_monitoring=self.installer_settings.monitoring_enabled,
             )
             conf_file.save()
 

--- a/raiden_installer/tokens.py
+++ b/raiden_installer/tokens.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Dict, Generic, NewType, Optional, TypeVar
 
 from raiden_contracts.constants import CONTRACTS_VERSION
-from raiden_installer import default_settings, network_settings, log
+from raiden_installer import default_settings
 
 Eth_T = TypeVar("Eth_T", int, Decimal, float, str, "Wei")
 Token_T = TypeVar("Token_T")
@@ -276,10 +276,6 @@ class RequiredAmounts:
                 Erc20Token.find_by_ticker(settings.transfer_token.ticker, settings.network),
             ),
         )
-
-    @staticmethod
-    def for_network(network_name):
-        return RequiredAmounts.from_settings(network_settings[network_name])
 
 
 @dataclass

--- a/raiden_installer/tokens.py
+++ b/raiden_installer/tokens.py
@@ -4,7 +4,6 @@ from enum import Enum
 from typing import Dict, Generic, NewType, Optional, TypeVar
 
 from raiden_contracts.constants import CONTRACTS_VERSION
-from raiden_installer import default_settings
 
 Eth_T = TypeVar("Eth_T", int, Decimal, float, str, "Wei")
 Token_T = TypeVar("Token_T")
@@ -60,11 +59,13 @@ class Erc20Token(Currency):
 
     @property
     def address(self) -> str:
-        network = self.network or default_settings.network.lower()
+        if self.network is None:
+            raise TokenError(f"Network is not set for {self.ticker}")
+
         try:
-            return self.addresses[network]
+            return self.addresses[self.network]
         except KeyError:
-            raise TokenError(f"{self.ticker} is not deployed on {network}")
+            raise TokenError(f"{self.ticker} is not deployed on {self.network}")
 
     @staticmethod
     def find_by_ticker(ticker, network=None):

--- a/raiden_installer/web.py
+++ b/raiden_installer/web.py
@@ -328,16 +328,8 @@ if __name__ == "__main__":
         [
             url(r"/", IndexHandler, name="index"),
             url(r"/configurations", ConfigurationListHandler, name="configuration-list"),
-            url(
-                r"/setup/mainnet/(.*)",
-                SetupHandler,
-                name="setup"
-            ),
-            url(
-                r"/create_wallet/mainnet",
-                WalletCreationHandler,
-                name="create_wallet"
-            ),
+            url(r"/setup/(.*)", SetupHandler, name="setup"),
+            url(r"/create_wallet", WalletCreationHandler, name="create_wallet"),
             url(r"/account/(.*)", AccountDetailHandler, name="account"),
             url(r"/keystore/(.*)/(.*)", KeystoreHandler, name="keystore"),
             url(r"/launch/(.*)", LaunchHandler, name="launch"),

--- a/raiden_installer/web_testnet.py
+++ b/raiden_installer/web_testnet.py
@@ -110,16 +110,9 @@ if __name__ == "__main__":
     app = Application(
         [
             url(r"/", IndexHandler, name="index"),
-            url(r"/configurations", ConfigurationListHandler, name="configuration-list"), url(
-                r"/setup/goerli/(.*)",
-                SetupHandler,
-                name="setup"
-            ),
-            url(
-                r"/create_wallet/goerli",
-                WalletCreationHandler,
-                name="create_wallet"
-            ),
+            url(r"/configurations", ConfigurationListHandler, name="configuration-list"),
+            url(r"/setup/(.*)", SetupHandler, name="setup"),
+            url(r"/create_wallet", WalletCreationHandler, name="create_wallet"),
             url(r"/account/(.*)", AccountDetailHandler, name="account"),
             url(r"/keystore/(.*)/(.*)", KeystoreHandler, name="keystore"),
             url(r"/launch/(.*)", LaunchHandler, name="launch"),
@@ -137,7 +130,7 @@ if __name__ == "__main__":
         debug=DEBUG,
         static_path=os.path.join(RESOURCE_FOLDER_PATH, "static"),
         template_path=os.path.join(RESOURCE_FOLDER_PATH, "templates"),
-        installer_settings_name="goerli"
+        installer_settings_name="demo_env"
     )
 
     # port = (sum(ord(c) for c in "RAIDEN_WIZARD_TESTNET") + 1000) % 2 ** 16 - 1 = 2640

--- a/resources/conf/demo_env.toml
+++ b/resources/conf/demo_env.toml
@@ -1,16 +1,15 @@
 network = "goerli"
 client_release_channel = "demo_env"
-client_release_version = "v0.200.0-rc7"
+client_release_version = "v1.1.1"
 services_version = "test"
 ethereum_amount_required = 2e16
 # Special networking for Demoenvs
 routing_mode = "pfs"
-matrix_server = "https://t02.testtransport.raiden.network"
-pathfinding_service_address = "https://pfs.t02.testtransport.raiden.network"
-
+matrix_server = "https://transport.demo001.env.raiden.network"
+pathfinding_service_address = "https://pfs.demo001.env.raiden.network"
 
 [service_token]
-ticker = "RDN"
+ticker = "SVT"
 amount_required = 6e18
 swap_amount_1 = 10e18
 swap_amount_2 = 20e18


### PR DESCRIPTION
closes #283 

This PR makes the testnet wizard using the demoenv. Additionally when starting the webserver for goerli or mainnet it uses a hardcoded settings file. It should not be possible to change the settings by the user when the application started, because we want to reduce the decisions that a user has to make.

This PR fixes the problem that the wizard expected the settings file to be named like the network. This prevented from having two configurations for goerli. 