### PR TITLE
Use PFS on mainnet

### DIFF
--- a/resources/conf/mainnet.toml
+++ b/resources/conf/mainnet.toml
@@ -4,7 +4,7 @@ client_release_version = "v1.1.1"
 services_version = "mainnet"
 ethereum_amount_required = 125e15
 ethereum_amount_required_after_swap = 75e14
-routing_mode = "local"
+routing_mode = "pfs"
 
 [service_token]
 ticker = "RDN"


### PR DESCRIPTION
Close #331 

Somehow the Wizard was always generating a config with local routing and no one ever realized this. This makes the Wizard using the PFS when creating a config. 