### PR TITLE
Introduce versioning for CircleCI cache key to invalidate old caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 vars: 
-  - &cache_key raiden-wizard-{{ .Branch }}-{{ checksum "requirements.txt" }}
-  - &cache_key_fake_blockchain raiden-wizard-{{ .Branch }}-{{ checksum "tests/fake_blockchain/package-lock.json" }}
+  - &cache_key raiden-wizard-deps-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+  - &cache_key_fake_blockchain raiden-wizard-fake-blockchain-v1-{{ .Branch }}-{{ checksum "tests/fake_blockchain/package-lock.json" }}
 
 executors:
   python-executor:


### PR DESCRIPTION
This introduces a change in the CI cache keys to invalidate old caches. This is necessary because of the Codecov security breach (https://github.com/raiden-network/team/issues/933).