### PR TITLE
frontend: Migrate to use the new MetaMask API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- [#338] Adapted the MetaMask integration to the recent breaking changes.
+
 ## [1.1.0] - 2020-09-29
 
 ### Added
@@ -19,6 +23,7 @@
 
 [unreleased]: https://github.com/raiden-network/raiden-wizard/compare/v1.1.0...HEAD
 [1.1.0]: https://github.com/raiden-network/raiden-wizard/compare/v1.0.3...v1.1.0
+[#338]: https://github.com/raiden-network/raiden-wizard/issues/338
 [#308]: https://github.com/raiden-network/raiden-wizard/issues/308
 [#275]: https://github.com/raiden-network/raiden-wizard/pull/275
 [#273]: https://github.com/raiden-network/raiden-wizard/issues/273

--- a/resources/static/js/account.js
+++ b/resources/static/js/account.js
@@ -94,8 +94,15 @@ function showRamp() {
 }
 
 async function checkWeb3Network() {
+  let currentChainID;
+  try {
+    currentChainID = parseInt(await provider.request({ method: 'eth_chainId' }), 16);
+  } catch (error) {
+    alert('Could not retrieve the chaind id from the web3 provider.');
+    return false;
+  }
+
   const requiredChainID = CHAIN_ID;
-  const currentChainID = parseInt(await provider.request({ method: 'eth_chainId' }), 16);
   if (currentChainID != requiredChainID) {
     const currentChainName = CHAIN_ID_MAPPING[currentChainID];
     const requiredChainName = CHAIN_ID_MAPPING[requiredChainID];
@@ -110,10 +117,7 @@ async function checkWeb3Network() {
 async function connectWeb3() {
   let accounts = [];
   try {
-    accounts = await provider.request({ method: 'eth_accounts' });
-    if (accounts.length === 0) {
-      accounts = await provider.request({ method: 'eth_requestAccounts' });
-    }
+    accounts = await provider.request({ method: 'eth_requestAccounts' });
   } catch (error) {
     if (error.code === 4001) {
       // EIP-1193 userRejectedRequest error

--- a/resources/static/js/base.js
+++ b/resources/static/js/base.js
@@ -1,43 +1,7 @@
-const CHAIN_ID_MAPPING = {
-  1: "Mainnet",
-  3: "Ropsten",
-  4: "Rinkeby",
-  5: "Görli",
-  42: "Kovan",
-};
-
 var MAIN_VIEW_INTERVAL;
 var RUNNING_TIMERS = new Array();
 
 let video;
-
-async function connectWeb3() {
-  let has_web3 = Boolean(window.ethereum || window.web3);
-  if (has_web3) {
-    // Modern dapp browsers...
-    if (window.ethereum) {
-      console.log("Using modern dapp browser");
-      window.web3 = new Web3(ethereum);
-      try {
-        // Request account access if needed
-        await ethereum.enable();
-      } catch (error) {
-        console.log(error);
-      }
-    }
-    // Legacy dapp browsers...
-    else if (window.web3) {
-      console.log("Using legacy web3");
-      window.web3 = new Web3(web3.currentProvider);
-    }
-    // Non-dapp browsers...
-    else {
-      console.log(
-        "Non-Ethereum browser detected. You should consider trying MetaMask!"
-      );
-    }
-  }
-}
 
 function runMainView() {
   if (typeof window.main === "function") {

--- a/resources/templates/account.html
+++ b/resources/templates/account.html
@@ -106,5 +106,6 @@
       {% end %}
   </script>
   <script type="text/javascript" src="{{ static_url('js/account.js') }}"></script>
+  <script src="https://unpkg.com/@metamask/detect-provider/dist/detect-provider.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@ramp-network/ramp-instant-sdk/dist/ramp-instant-sdk.umd.min.js"></script>
 {% end %}


### PR DESCRIPTION
Fixes #338 

MetaMask removed the injected `window.web3` object recently, which we relied on. This broke our integration of MetaMask.

MetaMask should now be used through the `window.ethereum` API, which is specified by EIP 1193. This PR migrates the frontend to use this API to make the transaction request. The only place where we send a transaction from the frontend is for funding the user account.

This uses a small library (`@metamask/detect-provider`) to detect the rpc provider as recommended by MetaMask.