### PR TITLE
Use Raiden client version v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Use newest Raiden client version v2.0.0 - Bespin
+
 ### Fixed
 
 - [#338] Adapted the MetaMask integration to the recent breaking changes.

--- a/resources/conf/demo_env.toml
+++ b/resources/conf/demo_env.toml
@@ -1,6 +1,6 @@
 network = "goerli"
 client_release_channel = "demo_env"
-client_release_version = "v1.1.1"
+client_release_version = "v2.0.0"
 services_version = "test"
 ethereum_amount_required = 2e16
 # Special networking for Demoenvs

--- a/resources/conf/mainnet.toml
+++ b/resources/conf/mainnet.toml
@@ -1,6 +1,6 @@
 network = "mainnet"
 client_release_channel = "mainnet"
-client_release_version = "v1.1.1"
+client_release_version = "v2.0.0"
 services_version = "mainnet"
 ethereum_amount_required = 125e15
 ethereum_amount_required_after_swap = 75e14


### PR DESCRIPTION
Updates the Wizard to download the binary of the new Bespin release.