### PR TITLE
Update docs links to use readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can download the Raiden Wizard for either macOS or Linux.
 
 For detailed instructions on how to run the Raiden Wizard:
 
-Read the [Quick Start section of the documentation](https://docs.raiden.network/quick-start)
+Read the [Quick Start section of the documentation](https://raiden-network.readthedocs.io/en/stable/installation/quick-start/)
 
 ## For Developers
 

--- a/resources/templates/terms.html
+++ b/resources/templates/terms.html
@@ -49,8 +49,8 @@
         <ol class="inner-list">
           <li>
             The software can be downloaded from the download area 
-            <a href="https://docs.raiden.network/installation/quick-start/download-and-run-the-raiden-wizard" target="_blank">
-              https://docs.raiden.network/installation/quick-start/download-and-run-the-raiden-wizard 
+            <a href="https://raiden-network.readthedocs.io/en/stable/installation/quick-start/README.html#download-and-run-the-raiden-wizard" target="_blank">
+              https://raiden-network.readthedocs.io/en/stable/installation/quick-start/README.html#download-and-run-the-raiden-wizard
             </a> 
             in different versions for the operating systems named there. The corresponding installation 
             instructions are also given in the download area.


### PR DESCRIPTION
As our documentation was completely moved to readthedocs, this updates all links to it.