### PR TITLE
Revert "Remove Ramp Network integration"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [#317] Integrates Ramp Network for buying ETH with fiat.
+
 ## [1.2.0] - 2021-06-10
 
 ### Changed
@@ -31,6 +35,7 @@
 [1.2.0]: https://github.com/raiden-network/raiden-wizard/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/raiden-network/raiden-wizard/compare/v1.0.3...v1.1.0
 [#338]: https://github.com/raiden-network/raiden-wizard/issues/338
+[#317]: https://github.com/raiden-network/raiden-wizard/issues/317
 [#308]: https://github.com/raiden-network/raiden-wizard/issues/308
 [#275]: https://github.com/raiden-network/raiden-wizard/pull/275
 [#273]: https://github.com/raiden-network/raiden-wizard/issues/273

--- a/raiden_installer/shared_handlers.py
+++ b/raiden_installer/shared_handlers.py
@@ -21,6 +21,7 @@ from raiden_contracts.contract_manager import ContractManager, contracts_precomp
 from raiden_installer import get_resource_folder_path, load_settings, log
 from raiden_installer.account import Account, find_keystore_folder_path
 from raiden_installer.base import RaidenConfigurationFile
+from raiden_installer.constants import RAMP_API_KEY
 from raiden_installer.ethereum_rpc import Infura, make_web3_provider
 from raiden_installer.network import Network
 from raiden_installer.raiden import RaidenClient, RaidenClientError, temporary_passphrase_file
@@ -327,6 +328,7 @@ class AccountDetailHandler(BaseRequestHandler):
             "account.html",
             configuration_file=configuration_file,
             keystore=filename,
+            ramp_api_key=RAMP_API_KEY,
         )
 
 

--- a/resources/static/js/account.js
+++ b/resources/static/js/account.js
@@ -5,6 +5,7 @@ const CHAIN_ID_MAPPING = {
   5: "Görli",
   42: "Kovan",
 };
+const RAMP_BALANCE_TIMEOUT = 300000;
 
 let neededEthAmount = ETHEREUM_REQUIRED_AMOUNT;
 let provider;
@@ -16,6 +17,80 @@ function runFunding(configurationFileName) {
   };
   WEBSOCKET.send(JSON.stringify(message));
   toggleView();
+}
+
+function showRamp() {
+  const ramp = new rampInstantSdk.RampInstantSDK({
+    hostAppName: "Raiden Wizard",
+    hostLogoUrl:
+      "https://raw.githubusercontent.com/raiden-network/raiden-wizard/develop/resources/static/images/raiden_logo_black.svg",
+    hostApiKey: RAMP_API_KEY,
+    swapAmount: ETHEREUM_REQUIRED_AMOUNT.toString(),
+    swapAsset: "ETH",
+    userAddress: TARGET_ADDRESS,
+  });
+
+  const purchaseCreatedCallback = (event) => {
+    console.log(`Ramp purchase created with id ${event.payload.purchase.id}`);
+    ramp.unsubscribe('PURCHASE_CREATED', purchaseCreatedCallback);
+    toggleView();
+    const messages = [
+      "Waiting for confirmation of purchase",
+      "(If you chose manual bank transfer you can close the Wizard and come back once you received a confirmation by e-mail.)",
+    ];
+    addFeedbackMessage(messages);
+  };
+
+  const purchaseSuccessfulCallback = (event) => {
+    ramp.unsubscribe("PURCHASE_SUCCESSFUL", purchaseSuccessfulCallback);
+    addFeedbackMessage([
+      'Purchase successful!',
+      'Checking balance to get updated',
+    ]);
+
+    const boughtAmount = parseInt(event.payload.purchase.cryptoAmount);
+    let timeElapsed = 0;
+    let timer;
+    const checkBalance = async () => {
+      if (timeElapsed >= RAMP_BALANCE_TIMEOUT) {
+        if (timer) {
+          clearInterval(timer);
+        }
+        addErrorMessage([
+          `Balance did not get updated after ${
+            RAMP_BALANCE_TIMEOUT / 1000
+          } seconds!`,
+        ]);
+        return;
+      }
+
+      const balance = await getBalances(CONFIGURATION_DETAIL_URL);
+      if (balance && balance.ETH && balance.ETH.as_wei >= boughtAmount) {
+        addFeedbackMessage([
+          `Balance got updated. You now have ${balance.ETH.formatted}.`,
+        ]);
+        setTimeout(() => {
+          forceNavigation(SWAP_URL);
+        }, 5000);
+      }
+      timeElapsed += 10000;
+    };
+
+    checkBalance();
+    timer = setInterval(checkBalance, 10000);
+  };
+
+  const purchaseFailedCallback = () => {
+    if (!document.querySelector("#background-task-tracker").hidden) {
+      addErrorMessage(["Purchase failed! Try again..."]);
+    }
+  };
+
+  ramp
+    .on("PURCHASE_CREATED", purchaseCreatedCallback)
+    .on("PURCHASE_SUCCESSFUL", purchaseSuccessfulCallback)
+    .on("PURCHASE_FAILED", purchaseFailedCallback)
+    .show();
 }
 
 async function checkWeb3Network() {

--- a/resources/templates/account.html
+++ b/resources/templates/account.html
@@ -47,10 +47,21 @@
         </button>
     </div>
   {% else %}
-    <div class="action hidden" id="btns-web3">
+    <div class="action-list hidden" id="btns-web3">
       <button class="big" id="btn-web3-eth" onClick="sendEthViaWeb3();">
         <img src="{{ static_url('images/send.svg') }}" alt="Send" />
         Send {{ ethereum_required.formatted }}
+      </button>
+      <button 
+        class="big" 
+        id="btn-ramp-eth"
+        onClick="showRamp();"
+        title="By using this feature Raiden Wizard will connect to a third party service. 
+        Third party terms and conditions may apply."
+      >
+        <img src="{{ static_url('images/money.svg') }}" alt="Buy" />
+        Buy {{ ethereum_required.formatted }} &nbsp;
+        <img class="small" src="{{ static_url('images/external.svg') }}" alt="External service" />
       </button>
     </div>
   {% end %}
@@ -81,6 +92,7 @@
     const FAUCET_AVAILABLE = "{{ network.FAUCET_AVAILABLE }}";
     const CHAIN_ID = "{{ configuration_file.network.chain_id }}";
     const CONFIGURATION_FILE_NAME = "{{ configuration_file.file_name }}";
+    const RAMP_API_KEY = "{{ ramp_api_key }}";
 
     const GAS_PRICE_URL = "{{ reverse_url('gas_price', configuration_file.file_name) }}";
     const KEYSTORE_URL = "{{ reverse_url('keystore', configuration_file.file_name, keystore) }}";
@@ -95,4 +107,5 @@
   </script>
   <script type="text/javascript" src="{{ static_url('js/account.js') }}"></script>
   <script src="https://unpkg.com/@metamask/detect-provider/dist/detect-provider.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@ramp-network/ramp-instant-sdk/dist/ramp-instant-sdk.umd.min.js"></script>
 {% end %}

--- a/resources/templates/index.html
+++ b/resources/templates/index.html
@@ -28,7 +28,8 @@
       For you to be able to obtain the required tokens using the Software, the Software gives 
       you the option to interact directly with certain web services provided by third parties, 
       such as crypto-to-crypto exchanges - <a href="https://kyberswap.com/" target="_blank">Kyber</a> 
-      or <a href="https://uniswap.org" target="_blank">Uniswap</a>. The use of these options is purely 
+      or <a href="https://uniswap.org" target="_blank">Uniswap</a> or fiat-to-crypto exchanges such 
+      as <a href="https://ramp.network//" target="_blank">Ramp</a>. The use of these options is purely 
       voluntary and not required to use the Software if you fulfill the requirements.
     </p>
     <h3>Disclaimer regarding third party services</h3>


### PR DESCRIPTION
Reverts raiden-network/raiden-wizard#340

The bug on the Ramp widget was fixed by them. We didn't want to release the integration because of the bug. Now we can do so.

The code was reviewed already and does not need another check.