### PR TITLE
Add input field on account page for increasing ETH amount

### DIFF
--- a/resources/static/css/app.css
+++ b/resources/static/css/app.css
@@ -128,6 +128,17 @@ input[type=text] {
   margin-bottom: 15px;
 }
 
+input#eth-amount {
+  width: 90px;
+  margin-left: 10px;
+  font-size: 18px;
+  height: 46px;
+}
+
+span.small {
+  font-size: 18px;
+}
+
 .error-box {
   height: 28px;
 }

--- a/resources/static/css/app.scss
+++ b/resources/static/css/app.scss
@@ -177,6 +177,17 @@ input[type=text] {
     margin-bottom: 15px;
 }
 
+input#eth-amount {
+    width: 90px;
+    margin-left: 10px;
+    font-size: 18px;
+    height: 46px;
+}
+
+span.small {
+    font-size: 18px;
+}
+
 .error-box {
     height: 28px;
 }

--- a/resources/static/js/base.js
+++ b/resources/static/js/base.js
@@ -231,6 +231,14 @@ function checkAcknowledgements(check_input_elems, next_action_elem, callback) {
   });
 }
 
+function fromWei(value) {
+  return value / 10 ** 18;
+}
+
+function toWei(value) {
+  return value * 10 ** 18;
+}
+
 WEBSOCKET.onmessage = function (evt) {
   let message = JSON.parse(evt.data);
   let message_list_elem = document.querySelector(

--- a/resources/templates/account.html
+++ b/resources/templates/account.html
@@ -47,22 +47,40 @@
         </button>
     </div>
   {% else %}
-    <div class="action-list hidden" id="btns-web3">
-      <button class="big" id="btn-web3-eth" onClick="sendEthViaWeb3();">
-        <img src="{{ static_url('images/send.svg') }}" alt="Send" />
-        Send {{ ethereum_required.formatted }}
-      </button>
-      <button 
-        class="big" 
-        id="btn-ramp-eth"
-        onClick="showRamp();"
-        title="By using this feature Raiden Wizard will connect to a third party service. 
-        Third party terms and conditions may apply."
-      >
-        <img src="{{ static_url('images/money.svg') }}" alt="Buy" />
-        Buy {{ ethereum_required.formatted }} &nbsp;
-        <img class="small" src="{{ static_url('images/external.svg') }}" alt="External service" />
-      </button>
+    <div class="info-panel hidden" id="btns-web3">
+      <div>
+        <span class="small">ETH amount:</span>
+        <input 
+          id="eth-amount"
+          type="number" 
+          name="ethAmount" 
+          value="{{ethereum_required.value}}" 
+          min="{{ethereum_required.value}}"
+          step="0.01"
+          autocomplete="off"
+          required 
+        />
+      </div>
+      <div class="error-box">
+        <span class="error" id="eth-amount-error" hidden></span>
+      </div>
+      <div class="action-list">
+        <button class="big" id="btn-web3-eth" onClick="sendEthViaWeb3();">
+          <img src="{{ static_url('images/send.svg') }}" alt="Send" />
+          Send ETH
+        </button>
+        <button 
+          class="big" 
+          id="btn-ramp-eth"
+          onClick="showRamp();"
+          title="By using this feature Raiden Wizard will connect to a third party service. 
+          Third party terms and conditions may apply."
+        >
+          <img src="{{ static_url('images/money.svg') }}" alt="Buy" />
+          Buy ETH &nbsp;
+          <img class="small" src="{{ static_url('images/external.svg') }}" alt="External service" />
+        </button>
+      </div>
     </div>
   {% end %}
 {% end %}


### PR DESCRIPTION
A user who wants to buy more than the required amount of ETH cannot do this with Ramp, because the Ramp widget prohibits to change the value we pass through the API. By letting the user change the value beforehands, we can circumvent this restriction.

This adds an input field where a user can specify how much ETH they want to buy. If a user selects less than the required amount, an error is shown. The field is prefilled with the required amount, so there is no additional step if the user does not want to modify it.

As the functionality for changing the value of the tx in MetaMask is quite hidden, I decided to use the input field for both options.