### PR TITLE
Get Release v1.3.0 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.3.0] - 2021-07-05
+
 ### Added
 
 - [#317] Integrates Ramp Network for buying ETH with fiat.
@@ -31,7 +33,8 @@
 
 - [#273] Wizard detects if the user sends tokens to the new account without swapping.
 
-[unreleased]: https://github.com/raiden-network/raiden-wizard/compare/v1.2.0...HEAD
+[unreleased]: https://github.com/raiden-network/raiden-wizard/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/raiden-network/raiden-wizard/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/raiden-network/raiden-wizard/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/raiden-network/raiden-wizard/compare/v1.0.3...v1.1.0
 [#338]: https://github.com/raiden-network/raiden-wizard/issues/338


### PR DESCRIPTION
Needed to get develop up-to-date with master. The additional commits are here because an earlier release was rebased into master. These release PRs should only be merged with merge commits.